### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/rqt_paramedit/src/rqt_paramedit/param_edit.cpp
+++ b/rqt_paramedit/src/rqt_paramedit/param_edit.cpp
@@ -3,7 +3,7 @@
 #include <QMessageBox>
 #include "param_root_chooser.h"
  
-PLUGINLIB_DECLARE_CLASS(rqt_paramedit, ParamEdit, rqt_paramedit::ParamEdit, rqt_gui_cpp::Plugin)
+PLUGINLIB_EXPORT_CLASS(rqt_paramedit::ParamEdit, rqt_gui_cpp::Plugin)
 
 namespace rqt_paramedit
 {


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions